### PR TITLE
Update package.json repo URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "util",
     "clean"
   ],
-  "repository": "syntax-tree/mdast-squeeze-headings",
-  "bugs": "https://github.com/syntax-tree/mdast-squeeze-headings/issues",
+  "repository": "syntax-tree/mdast-squeeze-paragraphs",
+  "bugs": "https://github.com/syntax-tree/mdast-squeeze-paragraphs/issues",
   "author": "Eugene Sharygin <eush77@gmail.com>",
   "contributors": [
     "Eugene Sharygin <eush77@gmail.com>",


### PR DESCRIPTION
I came across this repo on npm and noticed that these links resulted in a 404 on GitHub. Updating these URLs to reflect this repo will fix this on the next publish to npm. 👍 

![image](https://user-images.githubusercontent.com/2344137/49499644-84c75580-f823-11e8-9cdb-3aa2a5a437ce.png)
